### PR TITLE
Final update for 4.03

### DIFF
--- a/XA65_V4_ChangeLog.txt
+++ b/XA65_V4_ChangeLog.txt
@@ -1,0 +1,79 @@
+#Original Script created 8/17/2010 by Michael Bogobowicz, Citrix Systems.
+#To contact, please message @mikebogo on Twitter
+#This script is designed to be run on a XenApp 6.5 server
+
+#Modifications by Carl Webster, CTP and independent consultant
+#webster@carlwebster.com
+#@carlwebster on Twitter
+#http://www.CarlWebster.com
+#modified from the original script for XenApp 6.5
+
+#Updated 30-Dec-2013
+#	Do not sort the array of Citrix AD policies before returning the array from the function.  Causes the array to not work when there is only one AD policy.
+#	The XenApp 6.5 Mobility Pack added a new User policy node with three settings
+#	Added four policy settings that are only for AD based Citrix policies
+
+#Updated 5-Dec-2013
+#	Fixed bug where XA65ConfigLog.udl was not found even if it existed
+#	Fixed bug where the functions in Citrix.GroupPolicy.Command.psm1 were not found
+#	Initialize switch parameters as $False
+
+#Updated 12-Nov-2013
+#	Added back in the French sections that somehow got removed
+
+#Updated 07-Nov-2013
+#	Changed link to Citrix.GroupPolicy.Commands.psm module to my Dropbox
+#	Changed the GetCtxGPOsInAD function to work in a Windows Workgroup environment
+#	The Hotfix array for Citrix hotfixes was not initialized correctly causing all installed Citrix hotfixes to show as not installed.
+#	Removed the .LINK section from the help text
+
+#	Version 4 of script is based on version 3.17 of XA65 script
+#	Add ability to process AD based Citrix policies
+#	Add Appendix A for Session Sharing information
+#	Add Appendix B for Server Major Items
+#	Add descriptions for Citrix Policy filter type
+#	Add detecting the running Operating System to handle Word 2007 oddness with Server 2003/2008 vs Windows 7 vs Server 2008 R2
+#	Add elapsed time to end of script
+#	Add extra testing for applications, load balancing policies and worker groups to report if none exist instead of issuing a warning
+#	Add get-date to all write-verbose statements
+#	Add missing "None" option to ICA\Visual Display\Moving Images\Progressive compression level
+#	Add more Write-Verbose statements
+#	Add option to SaveAs PDF
+#	Add setting Default tab stops at 36 points (1/2 inch in the USA)
+#	Add Software Inventory
+#	Add Summary Page
+#	Add support for non-English versions of Microsoft Word
+#	Add WMI hardware information for Computer System, Disks, Processor and Network Interface Cards
+#	Change all instances of using $Word.Quit() to also use proper garbage collection
+#	Change all occurrences of Access Session Conditions to Tables 
+#	Change Default Cover Page to Sideline since Motion is not in German Word
+#	Change Get-RegistryValue function to handle $null return value
+#	Change most $Global: variables to regular variables
+#	Change the test for the existence of XA65ConfigLog.udl from using .\ to $pwd.path
+#	Change wording of not being able to load the Citrix.GroupPolicy.Commands.psm1 module
+#	Change wording when script aborts from a blank company name
+#	Fix issues with Word 2007 SaveAs under (Server 2008 and Windows 7) and Server 2008 R2
+#	Fix logic error when comparing Citrix installed hotfixes to the recommended list
+#	Fix output and missing items from ICA\Printing\Client Printers\Printer driver mapping and compatibility
+#	Fix output of ICA\Adobe Flash Delivery\Flash Redirection\Flash URL compatibility list
+#	Fix output of ICA\MultiStream Connections\Multi-Port Policy
+#	Fix output of ICA\Printing\Drivers\Universal driver preference
+#	Fix output of ICA\Printing\Session printers
+#	Fix output of ICA\Printing\Universal Printing\Universal printing optimization defaults
+#	Fix output of Server Settings\Health Monitoring and Recovery\Health monitoring tests
+#	Fix WaitForPrintersToBeCreated policy setting
+#	Fixing ICA\Printing\Session printers and ICA\Printing\Client Printers\Printer driver mapping and compatibility  required a new Function Get-PrinterModifiedSettings to keep from having duplicate code from Session Printers
+#	Abort script if Farm information cannot be retrieved
+#	Align Tables on Tab stop boundaries
+#	Consolidated all the code to properly abort the script into a function AbortScript
+#	Force the -verbose common parameter to be $True if running PoSH V3 and later
+#	General code cleanup
+#	If cover page selected does not exist, abort script
+#	If running Word 2007 and the Save As PDF option is selected then verify the Save As PDF add-in is installed.  Abort script if not installed.
+#	In the Server section, change Published Application to a Table
+#	Load Balancing Policies: fixed display of "Apply to connections made through Access Gateway" and "Configure application connection preference based on worker group"
+#	Only process WMI hardware information if the server is online
+#	Strongly type all possible variables
+#	Update for changes to CTX129229
+#	Verify Get-HotFix cmdlet worked.  If not, write error and suggestion to document
+#	Verify Word object is created.  If not, write error & suggestion to document and abort script


### PR DESCRIPTION
#Updated 30-Dec-2013
#	Do not sort the array of Citrix AD policies before returning the array from the function.  Causes the array to not work when there is only one AD policy.
#	The XenApp 6.5 Mobility Pack added a new User policy node with three settings
#	Added four policy settings that are only for AD based Citrix policies