### PR TITLE
Final update for 4.11

### DIFF
--- a/XA65_Inventory_V41.ps1
+++ b/XA65_Inventory_V41.ps1
@@ -225,9 +225,9 @@
 	No objects are output from this script.  This script creates a Word or PDF document.
 .NOTES
 	NAME: XA65_Inventory_V41.ps1
-	VERSION: 4.1
+	VERSION: 4.11
 	AUTHOR: Carl Webster (with a lot of help from Michael B. Smith and Jeff Wouters)
-	LASTEDIT: January 19, 2013
+	LASTEDIT: April 1, 2014
 #>
 
 
@@ -417,6 +417,9 @@ If($Summary -eq $Null)
 #	Removed the extra blank line between Administrators
 #	The XenApp 6.5 Mobility Pack added a new User policy node with three settings
 #	Updated for CTX129229 that was updated on 31-Dec-2013
+#Version 4.11
+#	Save current settings for Spell Check and Grammar Check before disabling them
+#	Before closing Word, put Spelling and Grammar settings back to original
 
 
 Set-StrictMode -Version 2
@@ -4169,6 +4172,10 @@ $Word.ActiveDocument.DefaultTabStop = 36
 
 #Disable Spell and Grammar Check to resolve issue and improve performance (from Pat Coughlin)
 Write-Verbose "$(Get-Date): Disable grammar and spell checking"
+#bug reported 1-Apr-2014 by Tim Mangan
+#save current options first before turning them off
+$CurrentGrammarOption = $Word.Options.CheckGrammarAsYouType
+$CurrentSpellingOption = $Word.Options.CheckSpellingAsYouType
 $Word.Options.CheckGrammarAsYouType = $False
 $Word.Options.CheckSpellingAsYouType = $False
 
@@ -6709,6 +6716,11 @@ If($CoverPagesExist)
 	$ab = $Null
 	$abstract = $Null
 }
+
+#bug fix 1-Apr-2014
+#reset Grammar and Spelling options back to their original settings
+$Word.Options.CheckGrammarAsYouType = $CurrentGrammarOption
+$Word.Options.CheckSpellingAsYouType = $CurrentSpellingOption
 
 Write-Verbose "$(Get-Date): Save and Close document and Shutdown Word"
 If($WordVersion -eq $wdWord2007)

--- a/XA65_V4_ChangeLog.txt
+++ b/XA65_V4_ChangeLog.txt
@@ -8,6 +8,10 @@
 #http://www.CarlWebster.com
 #modified from the original script for XenApp 6.5
 
+#Version 4.11 1-Apr-2014
+#	Save current settings for Spell Check and Grammar Check before disabling them
+#	Before closing Word, put Spelling and Grammar settings back to original
+
 #Version 4.1 19-Jan-2014
 #	Added additional error checking when retrieving Network Interface WMI data
 #	Added additional Write-Verbose statements for the AD policy function


### PR DESCRIPTION
#Version 4.11
#	Save current settings for Spell Check and Grammar Check before disabling them
#	Before closing Word, put Spelling and Grammar settings back to original