### PR TITLE
Final update for 5.03

### DIFF
--- a/XA65_Inventory_V5.ps1
+++ b/XA65_Inventory_V5.ps1
@@ -86,9 +86,9 @@
 		Alphabet (Word 2010. Works)
 		Annual (Word 2010. Doesn't work well for this report)
 		Austere (Word 2010. Works)
-		Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly works in 2010 but 
-						Subtitle/Subject & Author fields need to be moved 
-						after title box is moved up)
+		Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly 
+		works in 2010 but Subtitle/Subject & Author fields need to be moved 
+		after title box is moved up)
 		Banded (Word 2013/2016. Works)
 		Conservative (Word 2010. Works)
 		Contrast (Word 2010. Works)
@@ -98,20 +98,22 @@
 		Filigree (Word 2013/2016. Works)
 		Grid (Word 2010/2013/2016. Works in 2010)
 		Integral (Word 2013/2016. Works)
-		Ion (Dark) (Word 2013/2016. Top date doesn't fit, box needs to be manually resized or font 
-						changed to 8 point)
-		Ion (Light) (Word 2013/2016. Top date doesn't fit, box needs to be manually resized or font 
-						changed to 8 point)
+		Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be 
+		manually resized or font changed to 8 point)
+		Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be 
+		manually resized or font changed to 8 point)
 		Mod (Word 2010. Works)
-		Motion (Word 2010/2013/2016. Works if top date is manually changed to 36 point)
+		Motion (Word 2010/2013/2016. Works if top date is manually changed to 
+		36 point)
 		Newsprint (Word 2010. Works but date is not populated)
 		Perspective (Word 2010. Works)
 		Pinstripes (Word 2010. Works)
-		Puzzle (Word 2010. Top date doesn't fit, box needs to be manually resized or font 
-					changed to 14 point)
+		Puzzle (Word 2010. Top date doesn't fit; box needs to be manually 
+		resized or font changed to 14 point)
 		Retrospect (Word 2013/2016. Works)
 		Semaphore (Word 2013/2016. Works)
-		Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 2010)
+		Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 
+		2010)
 		Slice (Dark) (Word 2013/2016. Doesn't work)
 		Slice (Light) (Word 2013/2016. Doesn't work)
 		Stacks (Word 2010. Works)
@@ -566,9 +568,9 @@
 	No objects are output from this script.  This script creates a Word or PDF document.
 .NOTES
 	NAME: XA65_Inventory_V5.ps1
-	VERSION: 5.02
+	VERSION: 5.03
 	AUTHOR: Carl Webster (with a lot of help from Michael B. Smith, Jeff Wouters and Iain Brighton)
-	LASTEDIT: December 17, 2019
+	LASTEDIT: May 9, 2020
 #>
 
 #endregion
@@ -582,13 +584,13 @@ Param(
 	[Switch]$HTML=$False,
 
 	[parameter(ParameterSetName='PDF',Mandatory=$False)] 
+	[parameter(ParameterSetName='Word',Mandatory=$False)] 
+	[Switch]$MSWord=$False,
+
 	[Switch]$PDF=$False,
 
 	[parameter(ParameterSetName='Text',Mandatory=$False)] 
 	[Switch]$Text=$False,
-
-	[parameter(ParameterSetName='Word',Mandatory=$False)] 
-	[Switch]$MSWord=$False,
 
 	[parameter(ParameterSetName='HTML',Mandatory=$False)] 
 	[parameter(ParameterSetName='PDF',Mandatory=$False)] 
@@ -774,6 +776,19 @@ Param(
 #http://www.CarlWebster.com
 #Version 5.00 created on June 1, 2015
 
+#V5.03 9-May-2020
+#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
+#	Add Receive Side Scaling setting to Function OutputNICItem
+#	Change color variables $wdColorGray15 and $wdColorGray05 from [long] to [int]
+#	Change location of the -Dev, -Log, and -ScriptInfo output files from the script folder to the -Folder location (Thanks to Guy Leech for the "suggestion")
+#	Change Text output to use [System.Text.StringBuilder]
+#		Updated Functions Line and SaveAndCloseTextDocument
+#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
+#	Remove the code that checks for default value for script parameters
+#	Update Function SetWordCellFormat to change parameter $BackgroundColor to [int]
+#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
+#	Update Help Text
+#
 #V5.02 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 
@@ -811,248 +826,6 @@ Set-StrictMode -Version 2
 $SaveEAPreference = $ErrorActionPreference
 $ErrorActionPreference = 'SilentlyContinue'
 
-If($Null -eq $AdminAddress)
-{
-	$AdminAddress = "LocalHost"
-}
-If($Null -eq $CompanyAddress)
-{
-	$CompanyAddress = ""
-}
-If($Null -eq $CompanyEmail)
-{
-	$CompanyEmail = ""
-}
-If($Null -eq $CompanyFax)
-{
-	$CompanyFax = ""
-}
-If($Null -eq $CompanyName)
-{
-	$CompanyName = ""
-}
-If($Null -eq $CompanyPhone)
-{
-	$CompanyPhone = ""
-}
-If($Null -eq $CoverPage)
-{
-	$CoverPage="Sideline"
-}
-If($Null -eq $UserName)
-{
-	$UserName=$env:username
-}
-If($Null -eq $HTML)
-{
-	$HTML = $False
-}
-If($Null -eq $MSWord)
-{
-	$MSWord = $False
-}
-If($Null -eq $PDF)
-{
-	$PDF = $False
-}
-If($Null -eq $Text)
-{
-	$Text = $False
-}
-If($Null -eq $Administrators)
-{
-	$Administrators=$False
-}
-If($Null -eq $Applications)
-{
-	$Applications=$False
-}
-If($Null -eq $Logging)
-{
-	$Logging=$False
-}
-If($Null -eq $StartDate)
-{
-	$StartDate = ((Get-Date -displayhint date).AddDays(-7))
-}
-If($Null -eq $EndDate)
-{
-	$EndDate = (Get-Date -displayhint date)
-}
-If($Null -eq $Summary)
-{
-	$Summary = $False
-}
-If($Null -eq $MaxDetails)
-{
-	$MaxDetails=$False
-}
-If($Null -eq $Policies)
-{
-	$Policies = $False
-}
-If($Null -eq $NoPolicies)
-{
-	$NoPolicies = $False
-}
-If($Null -eq $NoADPolicies)
-{
-	$NoADPolicies = $False
-}
-If($Null -eq $AddDateTime)
-{
-	$AddDateTime = $False
-}
-If($Null -eq $Folder)
-{
-	$Folder = ""
-}
-If($Null -eq $Hardware)
-{
-	$Hardware = $False
-}
-If($Null -eq $Software)
-{
-	$Software = $False
-}
-If($Null -eq $Section)
-{
-	$Section = "All"
-}
-If($Null -eq $Dev)
-{
-	$Dev = $False
-}
-If($Null -eq $ScriptInfo)
-{
-	$ScriptInfo = $False
-}
-If($Null -eq $Log)
-{
-	$Log = $False
-}
-
-If(!(Test-Path Variable:AdminAddress))
-{
-	$AdminAddress = "LocalHost"
-}
-If(!(Test-Path Variable:CompanyAddress))
-{
-	$CompanyAddress = ""
-}
-If(!(Test-Path Variable:CompanyEmail))
-{
-	$CompanyEmail = ""
-}
-If(!(Test-Path Variable:CompanyFax))
-{
-	$CompanyFax = ""
-}
-If(!(Test-Path Variable:CompanyName))
-{
-	$CompanyName = ""
-}
-If(!(Test-Path Variable:CompanyPhone))
-{
-	$CompanyPhone = ""
-}
-If(!(Test-Path Variable:CoverPage))
-{
-	$CoverPage="Sideline"
-}
-If(!(Test-Path Variable:UserName))
-{
-	$UserName=$env:username
-}
-If(!(Test-Path Variable:HTML))
-{
-	$HTML = $False
-}
-If(!(Test-Path Variable:MSWord))
-{
-	$MSWord = $False
-}
-If(!(Test-Path Variable:PDF))
-{
-	$PDF = $False
-}
-If(!(Test-Path Variable:Text))
-{
-	$Text = $False
-}
-If(!(Test-Path Variable:Administrators))
-{
-	$Administrators=$False
-}
-If(!(Test-Path Variable:Applications))
-{
-	$Applications=$False
-}
-If(!(Test-Path Variable:Logging))
-{
-	$Logging=$False
-}
-If(!(Test-Path Variable:StartDate))
-{
-	$StartDate = ((Get-Date -displayhint date).AddDays(-7))
-}
-If(!(Test-Path Variable:EndDate))
-{
-	$EndDate = (Get-Date -displayhint date)
-}
-If(!(Test-Path Variable:Summary))
-{
-	$Summary = $False
-}
-If(!(Test-Path Variable:MaxDetails))
-{
-	$MaxDetails=$False
-}
-If(!(Test-Path Variable:Policies))
-{
-	$Policies = $False
-}
-If(!(Test-Path Variable:NoPolicies))
-{
-	$NoPolicies = $False
-}
-If(!(Test-Path Variable:NoADPolicies))
-{
-	$NoADPolicies = $False
-}
-If(!(Test-Path Variable:AddDateTime))
-{
-	$AddDateTime = $False
-}
-If(!(Test-Path Variable:Folder))
-{
-	$Folder = ""
-}
-If(!(Test-Path Variable:Hardware))
-{
-	$Hardware = $False
-}
-If(!(Test-Path Variable:Software))
-{
-	$Software = $False
-}
-If(!(Test-Path Variable:Section))
-{
-	$Section = "All"
-}
-If(!(Test-Path Variable:Dev))
-{
-	$Dev = $False
-}
-If(!(Test-Path Variable:ScriptInfo))
-{
-	$ScriptInfo = $False
-}
-If(!(Test-Path Variable:Log))
-{
-	$Log = $False
-}
-
 If($Null -eq $MSWord)
 {
 	If($Text -or $HTML -or $PDF)
@@ -1068,31 +841,6 @@ If($Null -eq $MSWord)
 If($MSWord -eq $False -and $PDF -eq $False -and $Text -eq $False -and $HTML -eq $False)
 {
 	$MSWord = $True
-}
-
-If($Log) 
-{
-	#start transcript logging
-	$Script:ThisScriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
-	$Script:LogPath = "$Script:ThisScriptPath\XA65V5DocScriptTranscript_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
-	
-	try 
-	{
-		Start-Transcript -Path $Script:LogPath -Force -Verbose:$false | Out-Null
-		Write-Host "$(Get-Date): Transcript/log started at $Script:LogPath" -BackgroundColor Black -ForegroundColor Yellow
-		$Script:StartLog = $true
-	} 
-	catch 
-	{
-		Write-Host "$(Get-Date): Transcript/log failed at $Script:LogPath" -BackgroundColor Black -ForegroundColor Yellow
-		$Script:StartLog = $false
-	}
-}
-
-If($Dev)
-{
-	$Error.Clear()
-	$Script:DevErrorFile = "$($pwd.Path)\XA65V5InventoryScriptErrors_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
 }
 
 If($Null -eq $MSWord)
@@ -1157,7 +905,15 @@ Else
 		Write-Host "$(Get-Date): Text is $($Text)" -BackgroundColor Black -ForegroundColor Yellow
 		Write-Host "$(Get-Date): HTML is $($HTML)" -BackgroundColor Black -ForegroundColor Yellow
 	}
-	Write-Error "Unable to determine output parameter.  Script cannot continue"
+	Write-Error "
+	`n`n
+	`t`t
+	Unable to determine output parameter.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n
+	"
 	Exit
 }
 
@@ -1184,8 +940,20 @@ If($NoPolicies -and $Section -eq "Policies")
 {
 	#conflict
 	$ErrorActionPreference = $SaveEAPreference
-	Write-Error -Message "`n`tYou specified conflicting parameters.`n`n`tYou specified the $($Section) section but also selected NoPolicies.`n`n`tPlease change one of these options and rerun the script.`n`n
-	Script cannot continue."
+	Write-Error -Message "
+	`n`n
+	`t`t
+	You specified conflicting parameters.
+	`n`n
+	`t`t
+	You specified the $($Section) section but also selected NoPolicies.
+	`n`n
+	`t`t
+	Please change one of these options and rerun the script.
+	`n`n
+	Script cannot continue.
+	`n`n
+	"
 	Exit
 }
 
@@ -1207,7 +975,13 @@ Switch ($Section)
 If($ValidSection -eq $False)
 {
 	$ErrorActionPreference = $SaveEAPreference
-	Write-Error -Message "`n`tThe Section parameter specified, $($Section), is an invalid Section option.`n`tValid options are:
+	Write-Error -Message "
+	`n`n
+	`t`t
+	The Section parameter specified, $($Section), is an invalid Section option.
+	`n`n
+	`t`t
+	Valid options are:
 	
 	`t`tAdmins
 	`t`tApps
@@ -1220,7 +994,10 @@ If($ValidSection -eq $False)
 	`t`tZones
 	`t`tAll
 	
-	`tScript cannot continue."
+	`t`t
+	Script cannot continue.
+	`n`n
+	"
 	Exit
 }
 
@@ -1239,16 +1016,71 @@ If($Folder -ne "")
 		Else
 		{
 			#it exists but it is a file not a folder
-			Write-Error "Folder $Folder is a file, not a folder.  Script cannot continue"
+			Write-Error "
+			`n`n
+			`t`t
+			Folder $Folder is a file, not a folder.
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			"
 			Exit
 		}
 	}
 	Else
 	{
 		#does not exist
-		Write-Error "Folder $Folder does not exist.  Script cannot continue"
+		Write-Error "
+		`n`n
+		`t`t
+		Folder $Folder does not exist.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		Exit
 	}
+}
+
+If($Folder -eq "")
+{
+	$Script:pwdpath = $pwd.Path
+}
+Else
+{
+	$Script:pwdpath = $Folder
+}
+
+If($Script:pwdpath.EndsWith("\"))
+{
+	#remove the trailing \
+	$Script:pwdpath = $Script:pwdpath.SubString(0, ($Script:pwdpath.Length - 1))
+}
+
+If($Log) 
+{
+	#start transcript logging
+	$Script:LogPath = "$Script:pwdpath\XA65V5DocScriptTranscript_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
+	
+	try 
+	{
+		Start-Transcript -Path $Script:LogPath -Force -Verbose:$false | Out-Null
+		Write-Host "$(Get-Date): Transcript/log started at $Script:LogPath" -BackgroundColor Black -ForegroundColor Yellow
+		$Script:StartLog = $true
+	} 
+	catch 
+	{
+		Write-Host "$(Get-Date): Transcript/log failed at $Script:LogPath" -BackgroundColor Black -ForegroundColor Yellow
+		$Script:StartLog = $false
+	}
+}
+
+If($Dev)
+{
+	$Error.Clear()
+	$Script:DevErrorFile = "$Script:pwdpath\XA65V5InventoryScriptErrors_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
 }
 
 #V5.01  Add check if $Policies -eq $True, see if PowerShell session is elevated
@@ -1280,17 +1112,17 @@ If($Policies -eq $True)
 	{
 		#abort script
 		Write-Error "
-		`n
-		`n
-		`tThe Citrix Group Policy module cannot be loaded or found in an elevated PowerShell session.
-		`n
-		`n
-		`tThe Policies parameter was used and this is an elevated PowerShell session.
-		`n
-		`n
-		`tRerun the script from a non-elevated PowerShell session. The script will now close.
-		`n
-		`n"
+		`n`n
+		`t`t
+		The Citrix Group Policy module cannot be loaded or found in an elevated PowerShell session.
+		`n`n
+		`t`t
+		The Policies parameter was used and this is an elevated PowerShell session.
+		`n`n
+		`t`t
+		Rerun the script from a non-elevated PowerShell session. The script will now close.
+		`n`n
+		"
 		Write-Verbose "$(Get-Date): "
 		Exit
 	}
@@ -1310,7 +1142,8 @@ If($MSWord -or $PDF)
 	#http://groovy.codehaus.org/modules/scriptom/1.6.0/scriptom-office-2K3-tlb/apidocs/
 	#http://msdn.microsoft.com/en-us/library/office/aa211923(v=office.11).aspx
 	[int]$wdAlignPageNumberRight = 2
-	[long]$wdColorGray15 = 14277081
+	[int]$wdColorGray15 = 14277081
+	[int]$wdColorGray05 = 15987699 
 	[int]$wdMove = 0
 	[int]$wdSeekMainDocument = 0
 	[int]$wdSeekPrimaryFooter = 4
@@ -1414,7 +1247,7 @@ If($HTML)
 
 If($TEXT)
 {
-	$Script:output = ""
+	[System.Text.StringBuilder] $global:Output = New-Object System.Text.StringBuilder( 16384 )
 }
 #endregion
 
@@ -1735,7 +1568,7 @@ Function GetComputerWMIInfo
 				
 				If($? -and $Null -ne $ThisNic)
 				{
-					OutputNicItem $Nic $ThisNic
+					OutputNicItem $Nic $ThisNic $RemoteComputerName
 				}
 				ElseIf(!$?)
 				{
@@ -2163,9 +1996,9 @@ Function OutputProcessorItem
 
 Function OutputNicItem
 {
-	Param([object]$Nic, [object]$ThisNic)
+	Param([object]$Nic, [object]$ThisNic, [string]$RemoteComputerName)
 	
-	$powerMgmt = Get-WmiObject MSPower_DeviceEnable -Namespace root\wmi | Where-Object {$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
+	$powerMgmt = Get-WmiObject -computername $RemoteComputerName MSPower_DeviceEnable -Namespace root\wmi | Where-Object{$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
 
 	If($? -and $Null -ne $powerMgmt)
 	{
@@ -2184,26 +2017,48 @@ Function OutputNicItem
 	}
 	
 	$xAvailability = ""
-	Switch ($processor.availability)
+	Switch ($ThisNic.availability)
 	{
-		1	{$xAvailability = "Other"; Break}
-		2	{$xAvailability = "Unknown"; Break}
-		3	{$xAvailability = "Running or Full Power"; Break}
-		4	{$xAvailability = "Warning"; Break}
-		5	{$xAvailability = "In Test"; Break}
-		6	{$xAvailability = "Not Applicable"; Break}
-		7	{$xAvailability = "Power Off"; Break}
-		8	{$xAvailability = "Off Line"; Break}
-		9	{$xAvailability = "Off Duty"; Break}
-		10	{$xAvailability = "Degraded"; Break}
-		11	{$xAvailability = "Not Installed"; Break}
-		12	{$xAvailability = "Install Error"; Break}
-		13	{$xAvailability = "Power Save - Unknown"; Break}
-		14	{$xAvailability = "Power Save - Low Power Mode"; Break}
-		15	{$xAvailability = "Power Save - Standby"; Break}
-		16	{$xAvailability = "Power Cycle"; Break}
-		17	{$xAvailability = "Power Save - Warning"; Break}
+		1		{$xAvailability = "Other"; Break}
+		2		{$xAvailability = "Unknown"; Break}
+		3		{$xAvailability = "Running or Full Power"; Break}
+		4		{$xAvailability = "Warning"; Break}
+		5		{$xAvailability = "In Test"; Break}
+		6		{$xAvailability = "Not Applicable"; Break}
+		7		{$xAvailability = "Power Off"; Break}
+		8		{$xAvailability = "Off Line"; Break}
+		9		{$xAvailability = "Off Duty"; Break}
+		10		{$xAvailability = "Degraded"; Break}
+		11		{$xAvailability = "Not Installed"; Break}
+		12		{$xAvailability = "Install Error"; Break}
+		13		{$xAvailability = "Power Save - Unknown"; Break}
+		14		{$xAvailability = "Power Save - Low Power Mode"; Break}
+		15		{$xAvailability = "Power Save - Standby"; Break}
+		16		{$xAvailability = "Power Cycle"; Break}
+		17		{$xAvailability = "Power Save - Warning"; Break}
 		Default	{$xAvailability = "Unknown"; Break}
+	}
+
+	#attempt to get Receive Side Scaling setting
+	$RSSEnabled = "N/A"
+	Try
+	{
+		#https://ios.developreference.com/article/10085450/How+do+I+enable+VRSS+(Virtual+Receive+Side+Scaling)+for+a+Windows+VM+without+relying+on+Enable-NetAdapterRSS%3F
+		$RSSEnabled = (Get-WmiObject -ComputerName $RemoteComputerName MSFT_NetAdapterRssSettingData -Namespace "root\StandardCimV2" -ea 0).Enabled
+
+		If($RSSEnabled)
+		{
+			$RSSEnabled = "Enabled"
+		}
+		ELse
+		{
+			$RSSEnabled = "Disabled"
+		}
+	}
+	
+	Catch
+	{
+		$RSSEnabled = "Not available on $Script:RunningOS"
 	}
 
 	$xIPAddress = @()
@@ -2282,6 +2137,7 @@ Function OutputNicItem
 		}
 		$NicInformation += (@{ Data = "Availability"; Value = $xAvailability; }) 
 		$NicInformation += (@{ Data = "Allow the computer to turn off this device to save power"; Value = $PowerSaving; }) 
+		$NicInformation += @{ Data = "Receive Side Scaling"; Value = $RSSEnabled; }
 		$NicInformation += (@{ Data = "Physical Address"; Value = $Nic.macaddress; }) 
 		If($xIPAddress.Count -gt 1)
 		{
@@ -2393,6 +2249,7 @@ Function OutputNicItem
 		Line 2 "Availability`t`t: " $xAvailability
 		Line 2 "Allow computer to turn "
 		Line 2 "off device to save power: " $PowerSaving
+		Line 2 "Receive Side Scaling`t: " $RSSEnabled
 		Line 2 "Physical Address`t: " $nic.macaddress
 		Line 2 "IP Address`t`t: " $xIPAddress[0]
 		$cnt = -1
@@ -2494,6 +2351,7 @@ Function OutputNicItem
 		$rowdata += @(,('Availability',($htmlsilver -bor $htmlbold),$xAvailability,$htmlwhite))
 		$rowdata += @(,('Allow the computer to turn off this device to save power',($htmlsilver -bor $htmlbold),$PowerSaving,$htmlwhite))
 		$rowdata += @(,('Physical Address',($htmlsilver -bor $htmlbold),$Nic.macaddress,$htmlwhite))
+		$rowdata += @(,('Receive Side Scaling',($htmlsilver -bor $htmlbold),$RSSEnabled,$htmlwhite))
 		$rowdata += @(,('IP Address',($htmlsilver -bor $htmlbold),$xIPAddress[0],$htmlwhite))
 		$cnt = -1
 		ForEach($tmp in $xIPAddress)
@@ -3107,7 +2965,18 @@ Function SetupWord
 	{
 		Write-Warning "The Word object could not be created.  You may need to repair your Word installation."
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tThe Word object could not be created.  You may need to repair your Word installation.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		The Word object could not be created.
+		`n`n
+		`t`t
+		You may need to repair your Word installation.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		Exit
 	}
 
@@ -3124,7 +2993,15 @@ Function SetupWord
 	If(!($Script:WordLanguageValue -gt -1))
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tUnable to determine the Word language value.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		Unable to determine the Word language value.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 	Write-Host "$(Get-Date): Word language value is $($Script:WordLanguageValue)" -BackgroundColor Black -ForegroundColor Yellow
@@ -3149,13 +3026,44 @@ Function SetupWord
 	ElseIf($Script:WordVersion -eq $wdWord2007)
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tMicrosoft Word 2007 is no longer supported.`n`n`t`tScript will end.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		Microsoft Word 2007 is no longer supported.
+		`n`n
+		`t`tScript will end.
+		`n`n
+		"
 		AbortScript
+	}
+	ElseIf($Script:WordVersion -eq 0)
+	{
+		Write-Error "
+		`n`n
+		`t`t
+		The Word Version is 0. You should run a full online repair of your Office installation.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
+		Exit
 	}
 	Else
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tYou are running an untested or unsupported version of Microsoft Word.`n`n`t`tScript will end.`n`n`t`tPlease send info on your version of Word to webster@carlwebster.com`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		You are running an untested or unsupported version of Microsoft Word.
+		`n`n
+		`t`t
+		Script will end.
+		`n`n
+		`t`t
+		Please send info on your version of Word to webster@carlwebster.com
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3297,7 +3205,15 @@ Function SetupWord
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Host "$(Get-Date): Word language value $($Script:WordLanguageValue)" -BackgroundColor Black -ForegroundColor Yellow
 		Write-Host "$(Get-Date): Culture code $($Script:WordCultureCode)" -BackgroundColor Black -ForegroundColor Yellow
-		Write-Error "`n`n`t`tFor $($Script:WordProduct), $($CoverPage) is not a valid Cover Page option.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		For $($Script:WordProduct), $($CoverPage) is not a valid Cover Page option.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3360,7 +3276,15 @@ Function SetupWord
 	{
 		Write-Host "$(Get-Date): " -BackgroundColor Black -ForegroundColor Yellow
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tAn empty Word document could not be created.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		An empty Word document could not be created.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3369,7 +3293,15 @@ Function SetupWord
 	{
 		Write-Host "$(Get-Date): " -BackgroundColor Black -ForegroundColor Yellow
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tAn unknown error happened selecting the entire Word document for default formatting options.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		An unknown error happened selecting the entire Word document for default formatting options.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3610,21 +3542,35 @@ Function Get-RegKeyToObject
 #region Word, text, and HTML line output functions
 Function line
 #function created by Michael B. Smith, Exchange MVP
-#@essentialexchange on Twitter
-#http://TheEssentialExchange.com
+#@essentialexch on Twitter
+#https://essential.exchange/blog
 #for creating the formatted text report
 #created March 2011
 #updated March 2014
+# updated March 2019 to use StringBuilder (about 100 times more efficient than simple strings)
 {
-	Param( [int]$tabs = 0, [string]$name = '', [string]$value = '', [string]$newline = "`r`n", [switch]$nonewline )
-	While( $tabs -gt 0 ) { $Script:Output += "`t"; $tabs--; }
+	Param
+	(
+		[Int]    $tabs = 0, 
+		[String] $name = '', 
+		[String] $value = '', 
+		[String] $newline = [System.Environment]::NewLine, 
+		[Switch] $nonewline
+	)
+
+	while( $tabs -gt 0 )
+	{
+		$null = $global:Output.Append( "`t" )
+		$tabs--
+	}
+
 	If( $nonewline )
 	{
-		$Script:Output += $name + $value
+		$null = $global:Output.Append( $name + $value )
 	}
 	Else
 	{
-		$Script:Output += $name + $value + $newline
+		$null = $global:Output.AppendLine( $name + $value )
 	}
 }
 	
@@ -4624,7 +4570,7 @@ Function SetWordCellFormat
 		# Font size
 		[Parameter()] [ValidateNotNullOrEmpty()] [int] $Size = 0,
 		# Cell background color
-		[Parameter()] [AllowNull()] $BackgroundColor = $Null,
+		[Parameter()] [AllowNull()] [int]$BackgroundColor = $Null,
 		# Force solid background color
 		[Switch] $Solid,
 		[Switch] $Bold,
@@ -4927,7 +4873,7 @@ Function SaveandCloseTextDocument
 		$Script:FileName1 += "_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
 	}
 
-	Write-Output $Script:Output | Out-File $Script:Filename1
+	Write-Output $global:Output.ToString() | Out-File $Script:Filename1 4>$Null
 }
 
 Function SaveandCloseHTMLDocument
@@ -4939,28 +4885,13 @@ Function SetFileName1andFileName2
 {
 	Param([string]$OutputFileName)
 	
-	If($Folder -eq "")
-	{
-		$pwdpath = $pwd.Path
-	}
-	Else
-	{
-		$pwdpath = $Folder
-	}
-
-	If($pwdpath.EndsWith("\"))
-	{
-		#remove the trailing \
-		$pwdpath = $pwdpath.SubString(0, ($pwdpath.Length - 1))
-	}
-
 	#set $Script:Filename1 and $Script:Filename2 with no file extension
 	If($AddDateTime)
 	{
-		[string]$Script:FileName1 = "$($pwdpath)\$($OutputFileName)"
+		[string]$Script:FileName1 = "$($Script:pwdpath)\$($OutputFileName)"
 		If($PDF)
 		{
-			[string]$Script:FileName2 = "$($pwdpath)\$($OutputFileName)"
+			[string]$Script:FileName2 = "$($Script:pwdpath)\$($OutputFileName)"
 		}
 	}
 
@@ -4970,10 +4901,10 @@ Function SetFileName1andFileName2
 		
 		If(!$AddDateTime)
 		{
-			[string]$Script:FileName1 = "$($pwdpath)\$($OutputFileName).docx"
+			[string]$Script:FileName1 = "$($Script:pwdpath)\$($OutputFileName).docx"
 			If($PDF)
 			{
-				[string]$Script:FileName2 = "$($pwdpath)\$($OutputFileName).pdf"
+				[string]$Script:FileName2 = "$($Script:pwdpath)\$($OutputFileName).pdf"
 			}
 		}
 
@@ -4983,7 +4914,7 @@ Function SetFileName1andFileName2
 	{
 		If(!$AddDateTime)
 		{
-			[string]$Script:FileName1 = "$($pwdpath)\$($OutputFileName).txt"
+			[string]$Script:FileName1 = "$($Script:pwdpath)\$($OutputFileName).txt"
 		}
 		ShowScriptOptions
 	}
@@ -4991,7 +4922,7 @@ Function SetFileName1andFileName2
 	{
 		If(!$AddDateTime)
 		{
-			[string]$Script:FileName1 = "$($pwdpath)\$($OutputFileName).html"
+			[string]$Script:FileName1 = "$($Script:pwdpath)\$($OutputFileName).html"
 		}
 		SetupHTML
 		ShowScriptOptions
@@ -5220,7 +5151,18 @@ Function ProcessScriptSetup
 	{
 		#We're missing Citrix Snapins that we need
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "Missing Citrix PowerShell Snap-ins Detected, check the console above for more information. Are you sure you are running this script on a XenApp 6.5 Server? Script will now close."
+		Write-Error "
+		`n`n
+		`t`t
+		Missing Citrix PowerShell Snap-ins Detected, check the console above for more information.
+		`n`n
+		`t`t
+		Are you sure you are running this script on a XenApp 6.5 Server?
+		`n`n
+		`t`t
+		Script will now close.
+		`n`n
+		"
 		Exit
 	}
 	#>
@@ -5243,13 +5185,18 @@ Function ProcessScriptSetup
 	}
 	ElseIf(!(Check-LoadedModule "Citrix.GroupPolicy.Commands") -and $Policies -eq $True)
 	{
-		Write-Error "The Citrix Group Policy module Citrix.GroupPolicy.Commands.psm1 could not be loaded 
-		`nPlease see the Prerequisites section in the ReadMe file (https://carlwebster.sharefile.com/d-s8e92231489542428). 
-		`n
-		`n
-		`t`tBecause the Policies parameter was used the script will now close.
-		`n
-		`n"
+		Write-Error "
+		`n`n
+		`t`t
+		The Citrix Group Policy module Citrix.GroupPolicy.Commands.psm1 could not be loaded 
+		`n`n
+		`t`t
+		Please see the Prerequisites section in the ReadMe file (https://carlwebster.sharefile.com/d-s8e92231489542428). 
+		`n`n
+		`t`t
+		Because the Policies parameter was used the script will now close.
+		`n`n
+		"
 		Write-Host "$(Get-Date): " -BackgroundColor Black -ForegroundColor Yellow
 		Exit
 	}
@@ -5271,7 +5218,15 @@ Function ProcessScriptSetup
 		If(!(Test-Path "$($pwd.path)\SoftwareExclusions.txt"))
 		{
 			$ErrorActionPreference = $SaveEAPreference
-			Write-Error "Software inventory requested but $($pwd.path)\SoftwareExclusions.txt does not exist.  Script cannot continue."
+			Write-Error "
+			`n`n
+			`t`t
+			Software inventory requested but $($pwd.path)\SoftwareExclusions.txt does not exist.
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			"
 			Exit
 		}
 		
@@ -5280,7 +5235,15 @@ Function ProcessScriptSetup
 		If(!($?))
 		{
 			$ErrorActionPreference = $SaveEAPreference
-			Write-Error "There was an error accessing or reading $($pwd.path)\SoftwareExclusions.txt.  Script cannot continue."
+			Write-Error "
+			`n`n
+			`t`t
+			There was an error accessing or reading $($pwd.path)\SoftwareExclusions.txt.
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			"
 			Exit
 		}
 		$x = $Null
@@ -5316,7 +5279,15 @@ Function ProcessScriptSetup
 			$ErrorActionPreference = $SaveEAPreference
 			Write-Warning "This script cannot be run remotely against a Session-only Host Server."
 			Write-Warning "Use Set-XADefaultComputerName XA65ControllerServerName or run the script on a controller."
-			Write-Error "Script cannot continue.  See messages above."
+			Write-Error "
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			`t`t
+			See messages above.
+			`n`n
+			"
 			Exit
 		}
 	}
@@ -5332,7 +5303,15 @@ Function ProcessScriptSetup
 			$ErrorActionPreference = $SaveEAPreference
 			Write-Warning "This script cannot be run on a Session-only Host Server if Remoting is not enabled."
 			Write-Warning "Use Set-XADefaultComputerName XA65ControllerServerName or run the script on a controller."
-			Write-Error "Script cannot continue.  See messages above."
+			Write-Error "
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			`t`t
+			See messages above.
+			`n`n
+			"
 			Exit
 		}
 	}
@@ -5364,11 +5343,27 @@ Function ProcessScriptSetup
 		Write-Warning "Farm information could not be retrieved"
 		If($Remoting)
 		{
-			Write-Error "A remote connection to $Script:RemoteXAServer could not be established.  Script cannot continue."
+			Write-Error "
+			`n`n
+			`t`t
+			A remote connection to $Script:RemoteXAServer could not be established.
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			"
 		}
 		Else
 		{
-			Write-Error "Farm information could not be retrieved.  Script cannot continue."
+			Write-Error "
+			`n`n
+			`t`t
+			Farm information could not be retrieved.
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			"
 		}
 		Exit
 	}
@@ -19146,7 +19141,7 @@ Function ProcessScriptEnd
 
 	If($ScriptInfo)
 	{
-		$SIFile = "$($pwd.Path)\XA65V5InventoryScriptInfo_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
+		$SIFile = "$Script:pwdpath\XA65V5InventoryScriptInfo_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
 		Out-File -FilePath $SIFile -InputObject ""
 		Out-File -FilePath $SIFile -Append -InputObject "Add DateTime       : $($AddDateTime)"
 		Out-File -FilePath $SIFile -Append -InputObject "AdminAddress       : $($AdminAddress)"

--- a/XA65_Inventory_V5_ReadMe.rtf
+++ b/XA65_Inventory_V5_ReadMe.rtf
@@ -1,6 +1,6 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
-{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
@@ -46,9 +46,9 @@ heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\li
 \widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext11 \ssemihidden \sunhideused 
 Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\kerning32\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \slocked \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\ai\af0\afs28 \ltrch\fcs0 
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\*\cs17 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \sunhideused \styrsid1274100 Hyperlink;}{\*\cs18 \additive 
-\rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpat0\chcbpat21 \sbasedon10 \ssemihidden \sunhideused \styrsid1274100 Unresolved Mention;}}{\*\rsidtbl \rsid884469\rsid1274100\rsid2574791\rsid5535194\rsid12078718\rsid13584788}{\mmathPr\mmathFont34\mbrkBin0
-\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2018\mo12\dy13\hr17\min44}{\revtim\yr2019\mo12\dy17\hr12\min48}{\version5}{\edmins25}{\nofpages18}{\nofwords5781}
-{\nofchars32957}{\nofcharsws38661}{\vern119}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpat0\chcbpat21 \sbasedon10 \ssemihidden \sunhideused \styrsid1274100 Unresolved Mention;}}{\*\rsidtbl \rsid884469\rsid1274100\rsid2574791\rsid3831778\rsid5535194\rsid12078718\rsid13584788}{\mmathPr
+\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2018\mo12\dy13\hr17\min44}{\revtim\yr2020\mo5\dy9\hr14\min29}{\version6}{\edmins27}
+{\nofpages18}{\nofwords5786}{\nofchars32985}{\nofcharsws38694}{\vern127}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot1274100 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDa0sDQytDCyNLQ0Nzc2MTVR0lEKTi0uzszPAykwrAUAhCllLywAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
@@ -88,8 +88,8 @@ Install the SDK (for the Help file) and Citrix Group Policy commands.
 nApp 6.5 server, go to }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s9b9df5f6350489f8"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid1274100 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003900620039006400
-6600350066003600330035003000340038003900660038000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000f8}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 
-https://carlwebster.sharefile.com/d-s9b9df5\hich\af37\dbch\af31505\loch\f37 f6350489f8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13584788 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+6600350066003600330035003000340038003900660038000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000f82d}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 
+https://carlwebster.sharefile.com/d-s9b9df\hich\af37\dbch\af31505\loch\f37 5f6350489f8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13584788 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid13584788 
 \par \hich\af37\dbch\af31505\loch\f37 b.\tab Save the file to your default download folder.
 \par \hich\af37\dbch\af31505\loch\f37 c.\tab Extract the file to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 C:\\XA65SDK}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 .
@@ -113,7 +113,7 @@ Install the Citrix Group Policy PowerShell module.
 \par }\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin1440\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 a.\tab In your Internet browser; go to }{\field{\*\fldinst {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-saaa440ebf364409a"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1274100 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073006100610061003400
-3400300065006200660033003600340034003000390061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 
+3400300065006200660033003600340034003000390061000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 
 https://carlwebster.sharefile.com/d-saaa440ebf364409a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 .
 \par \hich\af37\dbch\af31505\loch\f37 b.\tab Save the file to your default download folder.
 \par \hich\af37\dbch\af31505\loch\f37 c.\tab Extract the file to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 C:\\XA6SDK}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 .
@@ -123,16 +123,16 @@ https://carlwebster.sharefile.com/d-saaa440ebf364409a}}}\sectd \ltrsect\linex0\s
 \\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 
 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 .
 \par }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 ii.\tab C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 
-\hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 .
-
+\hich\af37\dbch\af31505\loch\f37 , in a new folder named\hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid13584788 .
 \par }\pard \ltrpar\ql \fi-360\li1440\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin1440\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 e.\tab Close your Internet browser.
 \par }\pard \ltrpar\ql \fi-360\li720\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 3.\tab 
 If you use Configuration Logging, you will need to use a UDL file for the History section of the script to work.
 \par }\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin1440\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 a.\tab For an explanation, see}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid1274100 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1274100 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.wadewegner.com/2007/04/creati
-\hich\af37\dbch\af31505\loch\f37 ng-a-universal-data-link-udl/" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1274100 {\*\datafield 
+\f37\fs22\insrsid1274100 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1274100 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.wadewegner.com/2007/04/creat
+\hich\af37\dbch\af31505\loch\f37 ing-a-universal-data-link-udl/" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1274100 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba400000068007400740070003a002f002f007700770077002e0077006100640065007700650067006e00650072002e0063006f006d002f0032003000300037002f00300034002f006300720065006100740069006e00
-67002d0061002d0075006e006900760065007200730061006c002d0064006100740061002d006c0069006e006b002d00750064006c002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+67002d0061002d0075006e006900760065007200730061006c002d0064006100740061002d006c0069006e006b002d00750064006c002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000078}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs17\f37\fs22\ul\cf19\insrsid1274100\charrsid1274100 \hich\af37\dbch\af31505\loch\f37 Create a UDL File}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 .
 \par \hich\af37\dbch\af31505\loch\f37 b.\tab \hich\af37\dbch\af31505\loch\f37 The UDL file will need to be placed in the same folder as the XenApp 6.5 Inventory script.  The UDL file will need to be named XA65ConfigLog.udl.
 \par \hich\af37\dbch\af31505\loch\f37 c.\tab You will need to edit the UDL file and add ;Password}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 =ConfigLogDatabasePassword }{\rtlch\fcs1 \af37\afs22 
@@ -143,7 +143,7 @@ Provider=SQLOLEDB.1;Integrated Security=SSPI;Persist Security Info=False;User ID
 \hich\f37 x Support site for XenApp 6.5 and check for updates specific to the PowerShell cmdlets or Help Text.  For \'93\loch\f37 \hich\f37 Public Hotfixes for XenApp 6.5 for Windows Server 2008 R2\'94\loch\f37 , see }{\field{\*\fldinst {\rtlch\fcs1 
 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "http://tinyurl.com/XA65Updates"}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid1274100 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b5600000068007400740070003a002f002f00740069006e007900750072006c002e0063006f006d002f00580041003600350055007000640061007400650073000000795881f43b1d7f48af2c825dc485276300000000
-a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\ul\cf2\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 http://tinyurl.com/XA65Updates}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+a5ab00030000006c}}}{\fldrslt {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\ul\cf2\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 http://tinyurl.com/XA65Updates}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid13584788 .
 \par \hich\af37\dbch\af31505\loch\f37 5.\tab To gather software inventory, a file named SoftwareExclusions.txt }{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 MUST}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 
@@ -176,8 +176,8 @@ By default, a Microsoft Word document is created named after the XenApp 6.5 Farm
 HYPERLINK "http://carlwebster.com/using-my-citrix-xenapp-6-5-powershell-doumentation-script-with-remoting/\hich\af37\dbch\af31505\loch\f37 "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1274100 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd800000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007500730069006e0067002d006d0079002d006300690074007200690078002d0078006500
 6e006100700070002d0036002d0035002d0070006f007700650072007300680065006c006c002d0064006f0075006d0065006e0074006100740069006f006e002d007300630072006900700074002d0077006900740068002d00720065006d006f00740069006e0067002f000000795881f43b1d7f48af2c825dc485276300
-000000a5ab0003000050}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/using-my-citrix-xenapp-6-5-powershell-doumentation-script-with-r
-\hich\af37\dbch\af31505\loch\f37 emoting/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 
+000000a5ab000300005051}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/using-my-citrix-xenapp-6-5-powershell-doumentation-script-with-
+\hich\af37\dbch\af31505\loch\f37 remoting/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 
 \par 
 \par \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par 
@@ -185,9 +185,7 @@ HYPERLINK "http://carlwebster.com/using-my-citrix-xenapp-6-5-powershell-doumenta
 \par 
 \par \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid12078718 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \page }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 
-\hich\af2\dbch\af31505\loch\f2 PS C:\\ScriptTesting> get-help .\\XA65_Inventory_V5.ps1 -full
-\par 
-\par \hich\af2\dbch\af31505\loch\f2 NAME
+\hich\af2\dbch\af31505\loch\f2 NAME
 \par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\\hich\af2\dbch\af31505\loch\f2 XA65_Inventory_V5.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
@@ -195,22 +193,49 @@ HYPERLINK "http://carlwebster.com/using-my-citrix-xenapp-6-5-powershell-doumenta
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XA65_Inventory_V5.ps1 [-MSWord] [-AddDateTime] [-AdminAddress <String>] [-Administrators] [-Applications] [-CompanyAddress <String>] [-Compa\hich\af2\dbch\af31505\loch\f2 
-nyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-Dev] [-EndDate <DateTime>] [-Folder <String>] [-Hardware] [-Log] [-Logging]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-MaxDetails] [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptIn\hich\af2\dbch\af31505\loch\f2 
-fo] [-Section <String>] [-Software] [-StartDate <DateTime>] [-Summary] [-UserName <String>] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XA65_Inventory_V5.ps1 [-MSWord] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-Applications] [-CompanyAddress <String>] [-Compa\hich\af2\dbch\af31505\loch\f2 
+nyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-Dev] [-EndDate <DateTime>] [-Folder <String>] [-Hardware] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-Log] [-Logging]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 \hich\af2\dbch\af31505\loch\f2 
+ }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-MaxDetails] [-NoADPolicies] [-NoPolicies] [-Policies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-ScriptIn\hich\af2\dbch\af31505\loch\f2 
+fo] [-Section <String>] [-Software] [-StartDate <DateTime>] [-Summary] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-UserName <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XA65_Inventory_V5.ps1 [-HTML] [-AddDateTime] [-AdminAddress <String>] [-Administrators] [-Applications] [-Dev] [-EndDate \hich\af2\dbch\af31505\loch\f2 
-<DateTime>] [-Folder <String>] [-Hardware] [-Log] [-Logging] [-MaxDetails] [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] [-Software] [-StartDate <DateTime>] [-Summary] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XA65_Inventory_V5.ps1 [-HTML] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-Applications] [-Dev] [-EndDate \hich\af2\dbch\af31505\loch\f2 
+<DateTime>] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 <String>] [-Hardware] [-Log] [-Logging] [-MaxDetails] [-NoADPolicies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-Policies] [-ScriptInfo] [-Section <String>] [-Software] [-StartDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-Summary] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XA65_Inventory_\hich\af2\dbch\af31505\loch\f2 
-V5.ps1 [-PDF] [-AddDateTime] [-AdminAddress <String>] [-Administrators] [-Applications] [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-Dev] [-EndDate <Dat
-\hich\af2\dbch\af31505\loch\f2 e\hich\af2\dbch\af31505\loch\f2 Time>] [-Folder <String>] [-Hardware] [-Log] [-Logging] [-MaxDetails]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 \hich\af2\dbch\af31505\loch\f2  [}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 -NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-Section <String>] [-Software] [-StartDate <DateTime>] [-Summary] [-UserName <String>] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\XA65_Inventory_\hich\af2\dbch\af31505\loch\f2 V5.ps1 [-PDF] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-Applications] [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-Dev] [-EndDate <Date\hich\af2\dbch\af31505\loch\f2 
+Time>] [-Folder <String>] [-Hardware] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-Log] [-Logging] [-MaxDetails]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 
+\hich\af2\dbch\af31505\loch\f2  [}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 -NoADPolicies] [-NoPolicies] [-Policies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-Section <String>] [-Software] [-StartDate <DateTime>] [-Summary] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-UserName <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\\hich\af2\dbch\af31505\loch\f2 
-XA65_Inventory_V5.ps1 [-Text] [-AddDateTime] [-AdminAddress <String>] [-Administrators] [-Applications] [-Dev] [-EndDate <DateTime>] [-Folder <String>] [-Hardware] [-Log] [-Logging] [-MaxDetails] [-NoADPolicies] [-NoPolicies] [-Policies] [-ScriptInfo] [-
-\hich\af2\dbch\af31505\loch\f2 S\hich\af2\dbch\af31505\loch\f2 ection <String>] [-Software] [-StartDate <DateTime>] [-Summary] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\ScriptTesting\\\hich\af2\dbch\af31505\loch\f2 XA65_Inventory_V5.ps1 [-Text] [-AddDateTime] [-AdminAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 <String>] [-Administrators] [-Applications] [-Dev] [-EndDate <DateTime>] [-Folder }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 <String>] [-Hardware] [-Log] [-Logging] [-MaxDetails] [-NoADPolicies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-Policies] [-ScriptInfo] [-S\hich\af2\dbch\af31505\loch\f2 
+ection <String>] [-Software] [-StartDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 [-Summary] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
@@ -453,11 +478,11 @@ XA65_Inventory_V5.ps1 [-Text] [-AddDateTime] [-AdminAddress <String>] [-Administ
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016\hich\af2\dbch\af31505\loch\f2 , works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 poin\hich\af2\dbch\af31505\loch\f2 t)
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
@@ -467,27 +492,27 @@ XA65_Inventory_V5.ps1 [-Text] [-AddDateTime] [-AdminAddress <String>] [-Administ
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is u\hich\af2\dbch\af31505\loch\f2 sed when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?\hich\af2\dbch\af31505\loch\f2                     named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
+\par \hich\af2\dbch\af31505\loch\f2     -EndDate <Date\hich\af2\dbch\af31505\loch\f2 Time>
 \par \hich\af2\dbch\af31505\loch\f2         End date, in MM/DD/YYYY HH:MM format, for the Configuration Logging report.
 \par \hich\af2\dbch\af31505\loch\f2         Default is today's date.
 \par \hich\af2\dbch\af31505\loch\f2         If the EndDate is entered as 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2574791 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 
@@ -495,32 +520,32 @@ XA65_Inventory_V5.ps1 [-Text] [-AddDateTime] [-AdminAddress <String>] [-Administ
 \hich\af2\dbch\af31505\loch\f2  00:00:00.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ED.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wi\hich\af2\dbch\af31505\loch\f2 ldcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Specifies the optional output folder to save the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inp\hich\af2\dbch\af31505\loch\f2 ut?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 \hich\af2\dbch\af31505\loch\f2  
 \par \hich\af2\dbch\af31505\loch\f2        }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2  Network}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the \hich\af2\dbch\af31505\loch\f2 script be run from an elevated PowerShell session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 or}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 Local Administrator).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will a\hich\af2\dbch\af31505\loch\f2 dd to both the time it takes to run the script and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the\hich\af2\dbch\af31505\loch\f2  script and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 size}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 of the report.
 \par 
@@ -717,23 +742,23 @@ XA65_Inventory_V5.ps1 [-Text] [-AddDateTime] [-AdminAddress <String>] [-Administ
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XA65_Inventory_V5.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 5.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2574791 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 5.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster (with a lot of help from Michael B. Smith, Jeff Wouters and\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 \hich\af2\dbch\af31505\loch\f2 Iain Brighton)
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2574791 \hich\af2\dbch\af31505\loch\f2 December 17, 2019}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3831778 \hich\af2\dbch\af31505\loch\f2 May 9, 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12078718\charrsid12078718 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA65_Inventory_V5.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover P\hich\af2\dbch\af31505\loch\f2 age format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
@@ -744,14 +769,14 @@ XA65_Inventory_V5.ps1 [-Text] [-AddDateTime] [-AdminAddress <String>] [-Administ
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA65_Inventory_V5.ps1 -AdminAddress XA65ZDC
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Off\hich\af2\dbch\af31505\loch\f2 ice\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Mic\hich\af2\dbch\af31505\loch\f2 rosoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page\hich\af2\dbch\af31505\loch\f2  format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     XA65ZDC as the remote Collector to run the script against.
 \par 
 \par 
@@ -1099,7 +1124,7 @@ XA65_Inventory_V5.ps1 [-Text] [-AddDateTime] [-AdminAddress <String>] [-Administ
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1110,13 +1135,13 @@ XA65_Inventory_V5.ps1 [-Text] [-AddDateTime] [-AdminAddress <String>] [-Administ
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA65_Inventory\hich\af2\dbch\af31505\loch\f2 _V5.ps1 -Dev -ScriptInfo -Log
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  PS C:\\PSScript >.\\XA65_Inventory_V5.ps1 -Dev -ScriptInfo -Log
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $en\hich\af2\dbch\af31505\loch\f2 v:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserIn\hich\af2\dbch\af31505\loch\f2 fo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1276,8 +1301,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000050fb
-31910ab5d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000001060
+3a2e3826d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/XenApp65_Script_ChangeLog.txt
+++ b/XenApp65_Script_ChangeLog.txt
@@ -6,6 +6,19 @@
 
 #Version 5.00 created on June 1, 2015
 
+#V5.03 9-May-2020
+#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
+#	Add Receive Side Scaling setting to Function OutputNICItem
+#	Change color variables $wdColorGray15 and $wdColorGray05 from [long] to [int]
+#	Change location of the -Dev, -Log, and -ScriptInfo output files from the script folder to the -Folder location (Thanks to Guy Leech for the "suggestion")
+#	Change Text output to use [System.Text.StringBuilder]
+#		Updated Functions Line and SaveAndCloseTextDocument
+#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
+#	Remove the code that checks for default value for script parameters
+#	Update Function SetWordCellFormat to change parameter $BackgroundColor to [int]
+#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
+#	Update Help Text
+
 #V5.02 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 


### PR DESCRIPTION
#V5.03 9-May-2020
#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
#	Add Receive Side Scaling setting to Function OutputNICItem
#	Change color variables $wdColorGray15 and $wdColorGray05 from [long] to [int]
#	Change location of the -Dev, -Log, and -ScriptInfo output files from the script folder to the -Folder location (Thanks to Guy Leech for the "suggestion")
#	Change Text output to use [System.Text.StringBuilder]
#		Updated Functions Line and SaveAndCloseTextDocument
#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
#	Remove the code that checks for default value for script parameters
#	Update Function SetWordCellFormat to change parameter $BackgroundColor to [int]
#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
#	Update Help Text