### PR TITLE
Final update for 5.06

### DIFF
--- a/XA65_Inventory_V5_ReadMe.rtf
+++ b/XA65_Inventory_V5_ReadMe.rtf
@@ -1,6 +1,6 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
@@ -77,20 +77,20 @@ header;}{\*\cs21 \additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \f43\fs24 \sbasedo
 {\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23
 \leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
 \levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid2021001164}}{\*\listoverridetable{\listoverride\listid2021001164
-\listoverridecount0\ls1}{\listoverride\listid1727532117\listoverridecount0\ls2}{\listoverride\listid1883403245\listoverridecount0\ls3}}{\*\rsidtbl \rsid198195\rsid271053\rsid750078\rsid884469\rsid1274100\rsid2574791\rsid3809035\rsid3831778\rsid4619036
-\rsid5521306\rsid5535194\rsid5786526\rsid6908306\rsid8258152\rsid8871901\rsid10183552\rsid11956975\rsid12078718\rsid12526764\rsid13584788\rsid16411218}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1
-\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2018\mo12\dy13\hr17\min44}{\revtim\yr2021\mo12\dy1\hr4\min31}{\version13}{\edmins63}{\nofpages19}{\nofwords5942}{\nofchars33872}{\nofcharsws39735}{\vern35}}
+\listoverridecount0\ls1}{\listoverride\listid1727532117\listoverridecount0\ls2}{\listoverride\listid1883403245\listoverridecount0\ls3}}{\*\rsidtbl \rsid79499\rsid198195\rsid271053\rsid750078\rsid884469\rsid1274100\rsid2574791\rsid3809035\rsid3831778
+\rsid4211131\rsid4619036\rsid5521306\rsid5535194\rsid5786526\rsid6908306\rsid8258152\rsid8871901\rsid10183552\rsid11956975\rsid12078718\rsid12526764\rsid13584788\rsid16411218}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0
+\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2018\mo12\dy13\hr17\min44}{\revtim\yr2022\mo2\dy23\hr13\min30}{\version14}{\edmins69}{\nofpages19}{\nofwords5915}{\nofchars33718}{\nofcharsws39554}{\vern41}}
 {\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot1274100 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDa0sDQytDCyNLQ0Nzc2MTVR0lEKTi0uzszPAykwqgUAR3pIBCwAAAA=}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3809035 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8258152 \chftnsep 
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot1274100 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDa0sDQytDCyNLQ0Nzc2MTVR0lEKTi0uzszPAykwrgUABktTHSwAAAA=}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3809035 \rtlch\fcs1 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid4211131 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3809035 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8258152 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid4211131 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3809035 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8258152 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid4211131 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3809035 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8258152 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid4211131 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\footerr \ltrpar \pard\plain \ltrpar\s22\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3809035 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1024\langfe1024\noproof\insrsid3809035 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3809035 
@@ -107,7 +107,7 @@ header;}{\*\cs21 \additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \f43\fs24 \sbasedo
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid3809035 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13584788 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 One of the most\hich\af37\dbch\af31505\loch\f37  requested features added to Version 4 was support for non-English versions of Microsoft Word}{\rtlch\fcs1 \af37\afs22 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 One of the\hich\af37\dbch\af31505\loch\f37  most requested features added to Version 4 was support for non-English versions of Microsoft Word}{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid12526764 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3809035 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 The script supports the following languages:
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0 \ltrch\fcs0 \f3\insrsid13584788 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-720\li1080\ri0\nowidctlpar\wrapdefault\faauto\ls2\rin0\lin1080\itap0\pararsid3809035 {\rtlch\fcs1 \af0 \ltrch\fcs0 
@@ -136,7 +136,7 @@ Install the SDK (for the Help file) and Citrix Group Policy commands.
 \hich\af37\dbch\af31505\loch\f37 nApp 6.5 server, go to }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3809035\charrsid11956975 \hich\af37\dbch\af31505\loch\f37 
 HYPERLINK "https://carlwebster.sharefile.com/d-s9b9df5f6350489f8"}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3809035 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003900620039006400
-6600350066003600330035003000340038003900660038000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000f82d00000073}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid3809035\charrsid11956975 \hich\af37\dbch\af31505\loch\f37 
+6600350066003600330035003000340038003900660038000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000f82d0000007300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid3809035\charrsid11956975 \hich\af37\dbch\af31505\loch\f37 
 https://carlwebster.sharefile.com/d-s9b9\hich\af37\dbch\af31505\loch\f37 df5f6350489f8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid3809035\charrsid11956975 .}{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid3809035\charrsid11956975 
 \par {\listtext\pard\plain\ltrpar \s19 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid3809035\charrsid11956975 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 Save the file to your default download folder.
@@ -174,7 +174,7 @@ https://carlwebster.sharefile.com/d-s9b9\hich\af37\dbch\af31505\loch\f37 df5f635
 }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3809035\charrsid11956975 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.wadewegner.com/2007/04/creating-a-universal-data-link-udl/" }{\rtlch\fcs1 \af0 \ltrch\fcs0 
 \insrsid3809035 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba400000068007400740070003a002f002f007700770077002e0077006100640065007700650067006e00650072002e0063006f006d002f0032003000300037002f00300034002f006300720065006100740069006e00
-67002d0061002d0075006e006900760065007200730061006c002d0064006100740061002d006c0069006e006b002d00750064006c002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000007800000022}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+67002d0061002d0075006e006900760065007200730061006c002d0064006100740061002d006c0069006e006b002d00750064006c002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000780000002200}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs17\f37\fs22\ul\cf19\insrsid3809035\charrsid11956975 \hich\af37\dbch\af31505\loch\f37 Create a UDL File}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3809035\charrsid11956975 .
 \par {\listtext\pard\plain\ltrpar \s19 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid3809035\charrsid11956975 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 The\hich\af37\dbch\af31505\loch\f37  UDL file }{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12526764 \hich\af37\dbch\af31505\loch\f37 must be}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3809035\charrsid11956975 \hich\af37\dbch\af31505\loch\f37 
@@ -228,33 +228,33 @@ To gather software inventory, a file named SoftwareExclusions.txt }{\rtlch\fcs1 
 \f37\fs22\insrsid13584788 .
 \par }\pard \ltrpar\ql \fi-360\li720\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 4.\tab By default, }{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid12526764 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 a Microsoft Word document named after the XenApp 6.5 Farm.
-\par \hich\af37\dbch\af31505\loch\f37 5.\tab If you use the \hich\f37 \endash \hich\af37\dbch\af31505\loch\f37 PDF option, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12526764 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 a PDF file named after the XenApp 6.5 Farm.
+\par \hich\af37\dbch\af31505\loch\f37 5.\tab If you use the \hich\f37 \endash \loch\f37 PDF option, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12526764 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 a PDF file named after the XenApp 6.5 Farm.
 \par \hich\af37\dbch\af31505\loch\f37 6.\tab If you use the \hich\f37 \endash \loch\f37 HTML option, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12526764 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 an HTML file named after the XenApp 6.5 Farm.
-\par }\pard \ltrpar\ql \fi-360\li720\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\pararsid1274100 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 7.\tab If you use the \hich\f37 
-\endash \loch\f37 Text option,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12526764 \hich\af37\dbch\af31505\loch\f37  the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 
-a Text file named after the XenAp\hich\af37\dbch\af31505\loch\f37 p 6.5 Farm.
+\par }\pard \ltrpar\ql \fi-360\li720\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\pararsid1274100 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 7.\tab If 
+\hich\af37\dbch\af31505\loch\f37 you use the \hich\f37 \endash \loch\f37 Text option,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12526764 \hich\af37\dbch\af31505\loch\f37  the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 a Text file named after the XenApp 6.5 Farm.
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 To use the script with Remoting, read the following article:
 
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 
-HYPERLINK "http://carlwebster.com/using-my-citrix-xenapp-6-5-powershell-doumentation-script-with-remoting/"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1274100 {\*\datafield 
+HYPERLINK "http://carlwebster.com/using-my-citrix-xenapp-6-5-powershell-doumentation-script-with-remoting\hich\af37\dbch\af31505\loch\f37 /"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1274100 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd800000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007500730069006e0067002d006d0079002d006300690074007200690078002d0078006500
 6e006100700070002d0036002d0035002d0070006f007700650072007300680065006c006c002d0064006f0075006d0065006e0074006100740069006f006e002d007300630072006900700074002d0077006900740068002d00720065006d006f00740069006e0067002f000000795881f43b1d7f48af2c825dc485276300
-000000a5ab0003000050510037da3a}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/using-my-citrix-xenapp-6-5-powershell-doumentation-script-with-remoting/}}}
+000000a5ab0003000050510037da3a00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\ul\cf2\insrsid13584788 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/using-my-citrix-xenapp-6-5-powershell-doumentation-script-with-remoting/}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13584788 
 \par 
 \par \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par 
-\par \hich\af37\dbch\af31505\loch\f37 Get-Help .\\\hich\af37\dbch\af31505\loch\f37 XA65_Inventory_V5.ps1 \hich\f37 \endash \loch\f37 full
+\par \hich\af37\dbch\af31505\loch\f37 Get-Help .\\XA65_Inventory_V5.ps1 \hich\f37 \endash \loch\f37 full
 \par 
 \par \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid5521306 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13584788 \page }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5521306 \hich\af43\dbch\af31505\loch\f43 Help Text
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5521306 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \\\hich\af2\dbch\af31505\loch\f2 
-XA65_Inventory_V5.ps1
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306 \hich\af2\dbch\af31505\loch\f2 C:\\P\hich\af2\dbch\af31505\loch\f2 SScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \\
+\hich\af2\dbch\af31505\loch\f2 XA65_Inventory_V5.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenApp 6.5 farm.
@@ -469,27 +469,27 @@ cript runs fastest in PowerShell version 5.
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page if the Cover Page has the Fax field.
 \par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have a Fax field:
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                        Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2             Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                         Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Pos\hich\af2\dbch\af31505\loch\f2 ition?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is conta\hich\af2\dbch\af31505\loch\f2 ined in }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 on the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 computer running the script.
@@ -502,18 +502,18 @@ cript runs fastest in PowerShell version 5.
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for \hich\af2\dbch\af31505\loch\f2 the Cover Page if the Cover Page has the Phone field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for t\hich\af2\dbch\af31505\loch\f2 he Cover Page if the Cover Page has the Phone field.
 \par \hich\af2\dbch\af31505\loch\f2                 The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                         Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                         Exposure (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWO\hich\af2\dbch\af31505\loch\f2 RD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWOR\hich\af2\dbch\af31505\loch\f2 D and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charac\hich\af2\dbch\af31505\loch\f2 ters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charact\hich\af2\dbch\af31505\loch\f2 ers?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
@@ -522,7 +522,7 @@ cript runs fastest in PowerShell version 5.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
@@ -609,7 +609,8 @@ cript runs fastest in PowerShell version 5.
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid198195 
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on\hich\af2\dbch\af31505\loch\f2  Computer System, Disks, Processor}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid79499 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2  and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid198195 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 Netwo\hich\af2\dbch\af31505\loch\f2 rk}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid198195 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 Interface Cards
 \par 
@@ -674,61 +675,64 @@ cript runs fastest in PowerShell version 5.
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD based policy information from the output document.
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid79499 \hich\af2\dbch\af31505\loch\f2 AD-based}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 
+\hich\af2\dbch\af31505\loch\f2  policy information from the output document.
 \par \hich\af2\dbch\af31505\loch\f2         Includes only Farm policies created in AppCenter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, where there may be thousands
-\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep S\hich\af2\dbch\af31505\loch\f2 YSVOL from being searched.
+\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NoAD.
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  This parameter has an alias of NoAD.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Farm and Citrix AD based policy information from the output document.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    -NoPolicies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Farm and Citrix }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid79499 \hich\af2\dbch\af31505\loch\f2 AD-based}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 
+\hich\af2\dbch\af31505\loch\f2  policy information from the output document.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cau\hich\af2\dbch\af31505\loch\f2 se the Policies section to be set to False.
+\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies section to be set to False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by\hich\af2\dbch\af31505\loch\f2  default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value             \hich\af2\dbch\af31505\loch\f2    False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charac\hich\af2\dbch\af31505\loch\f2 ters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid79499 \hich\af2\dbch\af31505\loch\f2 AD-based}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2  Policies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause the report to take a very long time
 \par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Note: The Citrix Group\hich\af2\dbch\af31505\loch\f2  Policy PowerShell module will not load from an elevated
-\par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
+\par \hich\af2\dbch\af31505\loch\f2         Note: The Citrix Group Policy PowerShell module will not load from an elevated
+\par \hich\af2\dbch\af31505\loch\f2         PowerShell ses\hich\af2\dbch\af31505\loch\f2 sion.
 \par \hich\af2\dbch\af31505\loch\f2         If the module is manually imported, the module is not detected from an elevated
 \par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, \hich\af2\dbch\af31505\loch\f2 NoPolicies, and NoADPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies, and NoADPolicies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exc\hich\af2\dbch\af31505\loch\f2 lusive and priority is given to NoPolicies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    fal\hich\af2\dbch\af31505\loch\f2 se
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value            \hich\af2\dbch\af31505\loch\f2     False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ReportFooter [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs a footer section at the en\hich\af2\dbch\af31505\loch\f2 d of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs a footer section at the end of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of RF.
 \par 
@@ -736,26 +740,26 @@ cript runs fastest in PowerShell version 5.
 \par \hich\af2\dbch\af31505\loch\f2                 Report information:
 \par \hich\af2\dbch\af31505\loch\f2                         Created with: <Script Name> - Release Date: <Script Release Date>
 \par \hich\af2\dbch\af31505\loch\f2                         Script version: <Script Version>
-\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in Local Format>
-\par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days,\hich\af2\dbch\af31505\loch\f2  nn hours, nn minutes, nn.nn seconds
+\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in Lo\hich\af2\dbch\af31505\loch\f2 cal Format>
+\par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
 \par \hich\af2\dbch\af31505\loch\f2                         Ran from domain <Domain Name> by user <Username>
 \par \hich\af2\dbch\af31505\loch\f2                         Ran from the folder <Folder Name>
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Script Name and Script Release date are script-specific variables.
-\par \hich\af2\dbch\af31505\loch\f2         Star\hich\af2\dbch\af31505\loch\f2 t Date Time in Local Format is a script variable.
+\par \hich\af2\dbch\af31505\loch\f2         Script Name and Scrip\hich\af2\dbch\af31505\loch\f2 t Release date are script-specific variables.
+\par \hich\af2\dbch\af31505\loch\f2         Start Date Time in Local Format is a script variable.
 \par \hich\af2\dbch\af31505\loch\f2         Elapsed time is a calculated value.
 \par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:USERDNSDOMAIN.
 \par \hich\af2\dbch\af31505\loch\f2         Username is $env:USERNAME.
-\par \hich\af2\dbch\af31505\loch\f2         Folder Name is a script variable.
+\par \hich\af2\dbch\af31505\loch\f2         Folder Name is a s\hich\af2\dbch\af31505\loch\f2 cript variable.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script \hich\af2\dbch\af31505\loch\f2 to a text file.
+\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<Switc\hich\af2\dbch\af31505\loch\f2 hParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
@@ -850,8 +854,8 @@ cript runs fastest in PowerShell version 5.
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?L\hich\af2\dbch\af31505\loch\f2 
 inkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030049}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs17\f2\fs18\ul\cf19\insrsid5521306\charrsid16411218 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216
-}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004909}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs17\f2\fs18\ul\cf19\insrsid5521306\charrsid16411218 \hich\af2\dbch\af31505\loch\f2 
+https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None. \hich\af2\dbch\af31505\loch\f2 You cannot pipe objects to this script.
@@ -867,23 +871,22 @@ inkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 {\*\
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XA65_Inventory_V5.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 5.05
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 5.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid79499 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webste\hich\af2\dbch\af31505\loch\f2 r (with a lot of help from Michael B. Smith, Jeff Wouters and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10183552 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 Iain Brighton)
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid750078 \hich\af2\dbch\af31505\loch\f2 December 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 
-\hich\af2\dbch\af31505\loch\f2 , 2021
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid79499 \hich\af2\dbch\af31505\loch\f2 February 23, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA65_Inventory_V5.ps1
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all De\hich\af2\dbch\af31505\loch\f2 fault values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Def\hich\af2\dbch\af31505\loch\f2 ault values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for t\hich\af2\dbch\af31505\loch\f2 he Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for th\hich\af2\dbch\af31505\loch\f2 e Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -929,8 +932,6 @@ inkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 {\*\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA65_Inventory_V5.ps1 -TEXT
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This parameter is reserved for a future update and no output is created at this time.
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save th\hich\af2\dbch\af31505\loch\f2 e document as a formatted text file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
@@ -947,8 +948,6 @@ inkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 {\*\
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XA65_Inventory_V5.ps1 -HTML
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     This parameter is reserved for a future update and no output is created at this time.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompanyName="Carl
@@ -1092,7 +1091,7 @@ inkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 {\*\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its
 \par \hich\af2\dbch\af31505\loch\f2     installed applications.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1127,7 +1126,7 @@ inkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 {\*\
 \par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company \hich\af2\dbch\af31505\loch\f2 Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par 
@@ -1158,7 +1157,8 @@ inkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 {\*\
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA65_Inventory_v5.ps1 -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details\hich\af2\dbch\af31505\loch\f2  on Farm policies created in AppCenter but
-\par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     no Citrix }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid79499 \hich\af2\dbch\af31505\loch\f2 AD-based}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 
+ Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
@@ -1178,7 +1178,8 @@ inkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 {\*\
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA65_Inventory_v5.ps1 -Section Policies -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Farm policies created in AppCenter but
-\par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     no Citrix }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid79499 \hich\af2\dbch\af31505\loch\f2 AD-based}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 
+ Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
@@ -1195,13 +1196,13 @@ inkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 {\*\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XA65_Inventory_V5.ps1 -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XA6\hich\af2\dbch\af31505\loch\f2 5_Inventory_V5.ps1 -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $\hich\af2\dbch\af31505\loch\f2 env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1209,8 +1210,9 @@ inkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16411218 {\*\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid198195 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 
- at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid198195 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid198195 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 
+\hich\af2\dbch\af31505\loch\f2  at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid198195 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 \hich\af2\dbch\af31505\loch\f2 
+-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     Output filename will be XA65FarmName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid198195 \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5521306\charrsid5521306 
 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx
 \par 
@@ -1428,8 +1430,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000d099
-29a49ee6d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000050a0
+c7cceb28d801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/XenApp65_Script_ChangeLog.txt
+++ b/XenApp65_Script_ChangeLog.txt
@@ -6,6 +6,23 @@
 
 #Version 5.00 created on December 1, 2018
 
+#Version 5.06 23-Feb-2022
+#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
+#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
+#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
+#		For example: 20221225T0840107271.
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#		Added stopping the transcript log if the log was enabled and started
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
+#	Updated the help text
+#	Updated the ReadMe file
+
 #V5.05 1-Dec-2021
 #	Added a test to see if $AdminAddress equals $Env:ComputerName
 #		If they are the same, do not try and set up remoting since remoting is not needed


### PR DESCRIPTION
#Version 5.06 23-Feb-2022
#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
#		For example: 20221225T0840107271.
#	Fixed the German Table of Contents (Thanks to Rene Bigler)
#		From 
#			'de-'	{ 'Automatische Tabelle 2'; Break }
#		To
#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
#	In Function AbortScript, add test for the winword process and terminate it if it is running
#		Added stopping the transcript log if the log was enabled and started
#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
#	Updated the help text
#	Updated the ReadMe file